### PR TITLE
Fix for error, when listing with limit 5000

### DIFF
--- a/CoinmarketcapClient/CoinmarketcapData.cs
+++ b/CoinmarketcapClient/CoinmarketcapData.cs
@@ -40,8 +40,8 @@ namespace NoobsMuc.Coinmarketcap.Client
         public DateTime date_added { get; set; }
         public List<object> tags { get; set; }
         public double? max_supply { get; set; }
-        public double circulating_supply { get; set; }
-        public double total_supply { get; set; }
+        public double? circulating_supply { get; set; }
+        public double? total_supply { get; set; }
         public CurrenyInfo platform { get; set; }
         public int cmc_rank { get; set; }
         public DateTime last_updated { get; set; }
@@ -69,12 +69,12 @@ namespace NoobsMuc.Coinmarketcap.Client
 
     public class CurrenyPriceInfo
     {
-        public double price { get; set; }
+        public double? price { get; set; }
         public double? volume_24h { get; set; }
         public double? percent_change_1h { get; set; }
         public double? percent_change_24h { get; set; }
         public double? percent_change_7d { get; set; }
-        public double market_cap { get; set; }
+        public double? market_cap { get; set; }
         public DateTime last_updated { get; set; }
     }
 

--- a/CoinmarketcapClient/WebApiClient.cs
+++ b/CoinmarketcapClient/WebApiClient.cs
@@ -45,14 +45,14 @@ namespace NoobsMuc.Coinmarketcap.Client
                     Name = data.name,
                     Symbol = data.symbol,
                     Rank = data.cmc_rank.ToString(),
-                    Price = data.quote.CurrenyPriceInfo.price,
+                    Price = data.quote.CurrenyPriceInfo.price ?? 0d,
                     Volume24hUsd = data.quote.CurrenyPriceInfo.volume_24h ?? 0,
                     MarketCapUsd = data.quote.CurrenyPriceInfo.volume_24h ?? 0,
                     PercentChange1h = data.quote.CurrenyPriceInfo.percent_change_1h ?? 0,
                     PercentChange24h = data.quote.CurrenyPriceInfo.percent_change_24h ?? 0,
                     PercentChange7d = data.quote.CurrenyPriceInfo.percent_change_7d ?? 0,
                     LastUpdated = data.quote.CurrenyPriceInfo.last_updated,
-                    MarketCapConvert = data.quote.CurrenyPriceInfo.market_cap,
+                    MarketCapConvert = data.quote.CurrenyPriceInfo.market_cap ?? 0d,
                     ConvertCurrency = convert
                 };
 


### PR DESCRIPTION
Some doubles can be null, so this had to be reflected by the interface. See changes for more details.